### PR TITLE
DEV: address codacy warnings related to apps

### DIFF
--- a/src/divergent/cli.py
+++ b/src/divergent/cli.py
@@ -141,7 +141,7 @@ def prep(seqdir, suffix, outpath, numprocs, force_overwrite, moltype, limit):
     with dvgt_util.keep_running(), tempfile.TemporaryDirectory() as tmp_dir:
         if seqdir.is_file():
             convert2dstore = dvgt_io.dvgt_file_to_dir(dest=tmp_dir)
-            in_dstore = convert2dstore(seqdir)
+            in_dstore = convert2dstore(seqdir)  # pylint: disable=not-callable
         else:
             in_dstore = c3_data_store.DataStoreDirectory(source=seqdir, suffix=suffix)
             if not len(in_dstore):
@@ -181,7 +181,7 @@ def prep(seqdir, suffix, outpath, numprocs, force_overwrite, moltype, limit):
             ):
                 if not r:
                     print(r)
-                writer(r)
+                writer(r)  # pylint: disable=not-callable
                 progress.update(convert, advance=1, refresh=True)
 
     out_dstore.close()
@@ -272,11 +272,12 @@ def max(
         limit=limit,
         verbose=verbose,
     )
+    # turn off pylint check, since the function is made into a class
     finalise = dvgt_records.dvgt_final_max(
         stat=stat,
         min_size=min_size,
         verbose=verbose,
-    )
+    )  # pylint: disable=no-value-for-parameter
     result = dvgt_records.apply_app(
         app=app,
         seqids=seqids,
@@ -364,7 +365,7 @@ def nmost(
         seqids=seqids,
         numprocs=numprocs,
         verbose=verbose,
-        finalise=dvgt_records.dvgt_final_nmost(),
+        finalise=dvgt_records.dvgt_final_nmost(),  # pylint: disable=no-value-for-parameter
     )
     # user requested inclusions are added to the selected divergent set
     if include:

--- a/src/divergent/io.py
+++ b/src/divergent/io.py
@@ -90,7 +90,7 @@ class dvgt_load_seqs:
         seqs = [s for _, s, *_ in parser]
         return SeqArray(
             seqid=data_member.unique_id,
-            data=self.str2arr(b"-".join(seqs).decode("utf8")),
+            data=self.str2arr(b"-".join(seqs).decode("utf8")),  # pylint: disable=not-callable
             moltype=self.moltype,
             source=data_member.data_store.source,
         )

--- a/src/divergent/records.py
+++ b/src/divergent/records.py
@@ -311,7 +311,7 @@ def max_divergent(
             sr = SummedRecords.from_records(sr.records)
 
     if max_set:
-        app = dvgt_final_max(stat=stat, min_size=min_size, verbose=verbose)
+        app = dvgt_final_max(stat=stat, min_size=min_size, verbose=verbose)  # pylint: disable=no-value-for-parameter
         sr = app([sr])
     elif verbose:
         num_neg = sum(r.delta_jsd < 0 for r in [sr.lowest] + sr.records)
@@ -502,7 +502,7 @@ def records_from_seq_store(
     """
     dstore = dvgt_data_store.HDF5DataStore(seq_store, mode="r")
     make_record = member_to_kmerseq(k=k, moltype=moltype)
-    records = [make_record(m) for m in dstore.completed if m.unique_id in seq_names]
+    records = [make_record(m) for m in dstore.completed if m.unique_id in seq_names]  # pylint: disable=not-callable
     records = records[:limit] if limit else records
     for record in records:
         if not record:

--- a/tests/test_data_store.py
+++ b/tests/test_data_store.py
@@ -29,7 +29,7 @@ def brca1_5(brca1_seqs):
 @pytest.fixture(scope="function")
 def brca1_dstore(tmp_path):
     dstore_maker = dvgt_io.dvgt_file_to_dir(tmp_path / "brca1_dstore")
-    return dstore_maker(DATADIR / "brca1.fasta")
+    return dstore_maker(DATADIR / "brca1.fasta")  # pylint: disable=not-callable
 
 
 @pytest.fixture(scope="function")
@@ -37,7 +37,7 @@ def brca1_5_dstore(tmp_path, brca1_5):
     fasta_path = tmp_path / "brca1_5.fasta"
     brca1_5.write(fasta_path)
     dstore_maker = dvgt_io.dvgt_file_to_dir(tmp_path / "brca1_5_dstore")
-    return dstore_maker(fasta_path)
+    return dstore_maker(fasta_path)  # pylint: disable=not-callable
 
 
 @pytest.fixture(scope="function")
@@ -65,7 +65,7 @@ def test_prep_pipeline(brca1_5, brca1_5_dstore, hdf5_dstore_path, parallel):
     # check the sequence data matches
     seq_data = result.read("Cat")
     str_to_array = str2arr(moltype="dna")
-    orig_seq_data = str_to_array(str(brca1_5.get_seq("Cat")))
+    orig_seq_data = str_to_array(str(brca1_5.get_seq("Cat")))  # pylint: disable=not-callable
     assert_array_equal(seq_data, orig_seq_data)
 
 

--- a/tests/test_record.py
+++ b/tests/test_record.py
@@ -54,7 +54,7 @@ def seqarray():
 
 @pytest.mark.parametrize("seq,entropy", ((seq4eq, 2.0), (seq4one, 0.0)))
 def test_seqrecord_entropy(seq, entropy):
-    arr = str2arr()(str(seq))
+    arr = str2arr()(str(seq))  # pylint: disable=not-callable
     kcounts = kmer_counts(arr, 4, 1)
     sr = KmerSeq(kcounts=kcounts, name=seq.name)
     assert sr.entropy == entropy
@@ -74,7 +74,7 @@ def test_seqrecord_invalid_kcounts(kcounts):
 
 
 def test_seqrecord_compare():
-    arr = str2arr()(str(seq5))
+    arr = str2arr()(str(seq5))  # pylint: disable=not-callable
     kcounts = kmer_counts(arr, 4, 2)
     kwargs = dict(kcounts=kcounts)
     sr1 = KmerSeq(name="n1", **kwargs)
@@ -350,7 +350,7 @@ def test_kmer_freqs(seq, k):
         expect[states.index(kmer)] = v
 
     seq2array = str2arr()
-    arr = seq2array(str(seq))
+    arr = seq2array(str(seq))  # pylint: disable=not-callable
     got = kmer_counts(arr, 4, k)
     assert (got == expect).all()
 
@@ -363,8 +363,8 @@ def test_composable():
         return True
 
     sr = KmerSeq(kcounts=numpy.array([1, 2, 3, 4], dtype=int), name="a")
-    app = matched_sr()
-    got = app([sr])
+    app = matched_sr()  # pylint: disable=no-value-for-parameter
+    got = app([sr])  # pylint: disable=not-callable
     assert got
 
 
@@ -387,7 +387,7 @@ def test__gettype(dtype):
 @pytest.mark.parametrize("k", (1, 2, 3))
 def test_seqarray_to_record(seqarray, k):
     s2r = seqarray_to_kmerseq(k=k, moltype="dna")
-    rec = s2r(seqarray)
+    rec = s2r(seqarray)  # pylint: disable=not-callable
 
     assert rec.name == "seq1"
     rec.kfreqs.sum() == len(seqarray) - k + 1
@@ -407,7 +407,7 @@ def test_lazy_kmers(dstore, seqarray):
 
     lazy = lazy_kmers(member=member, k=2, moltype="dna")
     s2k = seqarray_to_kmerseq(k=2, moltype="dna")
-    expect = s2k(seqarray)
+    expect = s2k(seqarray)  # pylint: disable=not-callable
     assert_allclose(numpy.array(lazy), expect.kcounts)
 
 
@@ -421,8 +421,8 @@ def test_member_to_vector(dstore, seqarray):
 def test_member_to_kmerseq(dstore, seqarray):
     member = dstore.write(unique_id="seq1", data=seqarray.data)
     new_app = member_to_kmerseq(k=2, moltype="dna")
-    got = new_app(member)
+    got = new_app(member)  # pylint: disable=not-callable
     assert isinstance(got, KmerSeq)
     old_app = seqarray_to_kmerseq(k=2, moltype="dna")
-    expect = old_app(seqarray)
+    expect = old_app(seqarray)  # pylint: disable=not-callable
     assert_allclose(got.kcounts, expect.kcounts)

--- a/tests/test_records.py
+++ b/tests/test_records.py
@@ -18,7 +18,7 @@ def _get_kfreqs_per_seq(seqs, k=1):
     app = str2arr()
     result = {}
     for seq in seqs.seqs:
-        arr = app(str(seq))
+        arr = app(str(seq))  # pylint: disable=not-callable
         freqs = kmer_counts(arr, 4, k)
         result[seq.name] = freqs
     return result
@@ -148,8 +148,8 @@ def test_merge_summed_records(DATA_DIR, brca1_coll):
     path = DATA_DIR / "brca1.dvgtseqs"
     names = brca1_coll.names
     app = dvgt_records.dvgt_nmost(seq_store=path, n=5, k=1)
-    sr1 = app(names[:10])
-    sr2 = app(names[10:20])
+    sr1 = app(names[:10])  # pylint: disable=not-callable
+    sr2 = app(names[10:20])  # pylint: disable=not-callable
     rnames1 = sr1.record_names
     rnames2 = sr2.record_names
     assert set(rnames1) != set(rnames2)
@@ -159,34 +159,34 @@ def test_merge_summed_records(DATA_DIR, brca1_coll):
 
 def test_dvgt_select_max(brca1_coll):
     app = dvgt_records.dvgt_select_max(k=1, min_size=2, max_size=5)
-    got = app(brca1_coll)
+    got = app(brca1_coll)  # pylint: disable=not-callable
     assert 2 <= got.num_seqs <= 5
     app = dvgt_records.dvgt_select_max(k=1, min_size=2, max_size=5, seed=123)
-    got = app(brca1_coll)
+    got = app(brca1_coll)  # pylint: disable=not-callable
     assert 2 <= got.num_seqs <= 5
 
 
 @pytest.mark.parametrize("include", ("Human", ["Human"], ["Human", "Mouse"]))
 def test_dvgt_select_max_include(brca1_coll, include):
     app = dvgt_records.dvgt_select_max(k=1, min_size=2, max_size=5, include=include)
-    got = app(brca1_coll)
+    got = app(brca1_coll)  # pylint: disable=not-callable
     include = {include} if isinstance(include, str) else set(include)
     assert include <= set(got.names)
 
 
 def test_dvgt_select_nmost(brca1_coll):
     app = dvgt_records.dvgt_select_nmost(k=1, n=5)
-    got = app(brca1_coll)
+    got = app(brca1_coll)  # pylint: disable=not-callable
     assert got.num_seqs == 5
     # try setting a seed
     app = dvgt_records.dvgt_select_nmost(k=1, n=5, seed=123)
-    got = app(brca1_coll)
+    got = app(brca1_coll)  # pylint: disable=not-callable
     assert got.num_seqs == 5
 
 
 @pytest.mark.parametrize("include", ("Human", ["Human"], ["Human", "Mouse"]))
 def test_dvgt_select_nmost_keep(brca1_coll, include):
     app = dvgt_records.dvgt_select_nmost(k=1, n=5, include=include)
-    got = app(brca1_coll)
+    got = app(brca1_coll)  # pylint: disable=not-callable
     include = {include} if isinstance(include, str) else set(include)
     assert include <= set(got.names)

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -13,9 +13,9 @@ def test_str2arr():
     s = "ACGTT"
     expect = dna.alphabet.to_indices(s)
     app = dvgt_util.str2arr()
-    g = app(s)
+    g = app(s)  # pylint: disable=not-callable
     assert (g == expect).all()
-    g = app("ACGNT")
+    g = app("ACGNT")  # pylint: disable=not-callable
     assert g[-2] > 3  # index for non-canonical character > num_states
 
 


### PR DESCRIPTION
[CHANGED] added # pylint: disable=not-callable and # pylint: disable=no-value-for-parameter
    comments to turn of checking related to apps. The former is because codacy does not
    know that the apps are in fact callable. The latter because it does not know that
    the first argument to apps produced from functions is a deferred input.